### PR TITLE
Give up Github Resolution

### DIFF
--- a/give-up-github.md
+++ b/give-up-github.md
@@ -1,0 +1,13 @@
+# Give up Github Resolution
+
+WHEREAS, GitHub is a proprietary platform owned by Microsoft, a company historically unwelcoming to open-source projects and nonprofits,
+
+WHEREAS, Trusting GitHub does not seem like a good decision for the future of our community and the long-term accessibility of our code,
+
+WHEREAS, GitHub is no ally of copyleft and our AGPL licensing terms (https://sfconservancy.org/GiveUpGitHub/),
+
+WHEREAS, Obl.ong is a nonprofit organization and using GitHub does not align with our values as a for-profit enterprise,
+
+WHEREAS, Codeberg is a code forge governed by a democratic nonprofit organization in line with our values that has proven itself respectable stewards of the Forgejo project and is deeply committed to free software, 
+
+THEREFORE IT BE RESOLVED that Obl.ong shall migrate all of its GitHub repositories, issues, pull requests, and other data to Codeberg. This is to preserve our code and community for the long-term in a nonprofit and democratic organization operated in the public interest (Codeberg e.V.).


### PR DESCRIPTION
This resolution lays out the move away from Github to Codeberg and why it needs to be done.